### PR TITLE
se corrigio el pom.xml y se agrego correctamente las var al .properties

### DIFF
--- a/JPA_Pizzeria/pom.xml
+++ b/JPA_Pizzeria/pom.xml
@@ -149,7 +149,27 @@
 				</configuration>
 			</plugin>
 			
+			<!-- Add resource plugin with encoding configuration -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-resources-plugin</artifactId>
+				<version>3.3.1</version>
+				<configuration>
+					<encoding>UTF-8</encoding>
+					<nonFilteredFileExtensions>
+						<nonFilteredFileExtension>properties</nonFilteredFileExtension>
+					</nonFilteredFileExtensions>
+				</configuration>
+			</plugin>
+			
 		</plugins>
+		
+		<resources>
+			<resource>
+				<directory>src/main/resources</directory>
+				<filtering>true</filtering>
+			</resource>
+		</resources>
 	</build>
 
 </project>

--- a/JPA_Pizzeria/src/main/resources/application.properties
+++ b/JPA_Pizzeria/src/main/resources/application.properties
@@ -19,6 +19,9 @@ spring.jpa.generate-ddl=true
 # Opciones para la gestión de base de datos
 spring.jpa.hibernate.ddl-auto=update
 
+
+# Configuración del dialecto de Hibernate para MySQL
+
 #spring.application.name=JPA_Pizzeria
 
 #indicacion del driver para la conexion con java y mysql


### PR DESCRIPTION
This pull request mainly improves the Maven build configuration and resource handling for the `JPA_Pizzeria` project. It introduces a new resource plugin setup in the `pom.xml` to ensure proper encoding and resource filtering, and adds a comment to the `application.properties` file for clarity about Hibernate dialect configuration.

**Build and resource configuration improvements:**

* Added the `maven-resources-plugin` with UTF-8 encoding and specified that `.properties` files should not be filtered in `pom.xml` to ensure consistent resource processing.
* Configured the `<resources>` section in `pom.xml` to enable filtering for resources in `src/main/resources`, improving how environment-specific values can be injected during the build.

**Documentation and configuration clarity:**

* Added a comment in `application.properties` to clarify where to set the Hibernate dialect for MySQL, making the configuration easier to understand for future maintainers.