### PR TITLE
se agrego un filtro al pom

### DIFF
--- a/JPA_Pizzeria/pom.xml
+++ b/JPA_Pizzeria/pom.xml
@@ -169,6 +169,22 @@
 				<directory>src/main/resources</directory>
 				<filtering>true</filtering>
 			</resource>
+			
+			 <resource>
+            <directory>src/main/resources</directory>
+            <filtering>true</filtering>
+            <excludes>
+                <exclude>static/bootstrap-icons-1.13.1/fonts/*.woff2</exclude>
+            </excludes>
+        </resource>
+        <resource>
+            <directory>src/main/resources</directory>
+            <filtering>false</filtering>
+            <includes>
+                <include>static/bootstrap-icons-1.13.1/fonts/*.woff2</include>
+            </includes>
+        </resource>
+			
 		</resources>
 	</build>
 


### PR DESCRIPTION
This pull request updates the resource configuration in the `pom.xml` file to improve how static font files are handled during the build process. The main change is to ensure that `.woff2` font files for Bootstrap Icons are not filtered (i.e., not processed for variable replacement), which prevents potential corruption of these binary files.

Improvements to resource filtering and inclusion:

* Added a resource entry to explicitly exclude `.woff2` font files from filtering in the main resources section, preventing them from being processed as text files.
* Added a separate resource entry to include `.woff2` font files with filtering disabled, ensuring these binary files are copied as-is to the output.