### PR TITLE
nueva correcion pom

### DIFF
--- a/JPA_Pizzeria/pom.xml
+++ b/JPA_Pizzeria/pom.xml
@@ -165,16 +165,13 @@
 		</plugins>
 		
 		<resources>
-			<resource>
-				<directory>src/main/resources</directory>
-				<filtering>true</filtering>
-			</resource>
-			
-			 <resource>
+        <resource>
             <directory>src/main/resources</directory>
             <filtering>true</filtering>
             <excludes>
                 <exclude>static/bootstrap-icons-1.13.1/fonts/*.woff2</exclude>
+                <exclude>static/bootstrap-icons-1.13.1/fonts/*.ttf</exclude>
+                <exclude>static/bootstrap-icons-1.13.1/fonts/*.woff</exclude>
             </excludes>
         </resource>
         <resource>
@@ -182,10 +179,11 @@
             <filtering>false</filtering>
             <includes>
                 <include>static/bootstrap-icons-1.13.1/fonts/*.woff2</include>
+                <include>static/bootstrap-icons-1.13.1/fonts/*.ttf</include>
+                <include>static/bootstrap-icons-1.13.1/fonts/*.woff</include>
             </includes>
         </resource>
-			
-		</resources>
+    </resources>
 	</build>
 
 </project>


### PR DESCRIPTION
This pull request updates the resource filtering configuration in the `pom.xml` file to more accurately control which font files are filtered and which are not. The changes help ensure that all relevant font formats are correctly included or excluded as needed.

Resource filtering configuration updates:

* Added `.ttf` and `.woff` font formats to the list of excluded files from filtering, alongside `.woff2`, under the `static/bootstrap-icons-1.13.1/fonts/` directory.
* Updated the corresponding resource inclusion section to explicitly include `.ttf` and `.woff` font files, in addition to `.woff2`, when filtering is set to false.