### PR TITLE
actualizacion de application.properties para digitalOcean

### DIFF
--- a/JPA_Pizzeria/src/main/resources/application.properties
+++ b/JPA_Pizzeria/src/main/resources/application.properties
@@ -6,7 +6,7 @@ spring.application.name=JPA_Pizzeria
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 # Configuración para DigitalOcean
-spring.datasource.url=jdbc:mysql://${MYSQL_HOST:localhost}:${MYSQL_PORT:3306}/${MYSQL_DATABASE:pizzeria}
+spring.datasource.url=jdbc:mysql://${MYSQL_HOST:localhost}:${MYSQL_PORT:3306}/${MYSQL_DATABASE:pizzeria}?useSSL=true&requireSSL=true&verifyServerCertificate=false
 spring.datasource.username=${MYSQL_USER:root}
 spring.datasource.password=${MYSQL_PASSWORD:password}
 


### PR DESCRIPTION
This pull request makes a small change to the database connection configuration in `application.properties` to enhance security by enabling SSL for MySQL connections.

- Enabled SSL for the MySQL datasource by adding `useSSL=true`, `requireSSL=true`, and `verifyServerCertificate=false` to the JDBC URL in `application.properties`.